### PR TITLE
[fix] Corrigido z-index da barra de ações do editor

### DIFF
--- a/chrome/css/editor.css
+++ b/chrome/css/editor.css
@@ -190,7 +190,7 @@ html.sen-editor-noscroll, html.sen-editor-noscroll body {
     width: 100% !important;
     height: 100% !important;
     min-width: 860px !important;
-    z-index: 1051 !important;
+    z-index: 5051 !important;
     position: fixed !important;
     border: none !important;
 }


### PR DESCRIPTION
A topbar do site possui agora o `z-index` 5050, ficando acima da barra de ações do editor, que possuía 1051. Corrigido para 5051.

![GIF mostrando o problema](https://i.stack.imgur.com/ir82j.gif)